### PR TITLE
Moved TFsci to HRT, added guidelines

### DIFF
--- a/content.en/hrt.md
+++ b/content.en/hrt.md
@@ -6,3 +6,6 @@ weight: 1
 - [HRT.Cafe](https://hrt.cafe)
 - [DIY HRT](https://diyhrt.wiki)
 - [MtFHRT@groups.io](https://groups.io/g/MTFHRT)
+- [Transfeminine Science](https://transfemscience.org) - The original informative site on feminizing hormone therapy
+- [r/TransDIY](https://reddit.com/r/TransDIY) - Discussions on DIY HRT
+- [r/AskMtFHRT](https://reddit.com/r/AskMtFHRT) - Questions on feminizing hormone therapy

--- a/content.en/science.md
+++ b/content.en/science.md
@@ -16,3 +16,13 @@ weight: 4
 
 - [Vaginoplasty Modifications to Improve Vulvar Aesthetics](https://doi.org/10.1016/j.ucl.2019.07.008) (2019)
 - [Male-to-female vaginoplasty: Preecha‘s surgical technique](https://doi.org/10.3109/2000656X.2014.967253) (2014)
+
+## Guidelines for transgender health
+
+- WPATH: [Standards of Care for the Health of Transgender and Gender Diverse People](https://www.wpath.org/publications/soc), Version 8 (2022) \[[PDF](https://www.tandfonline.com/doi/pdf/10.1080/26895269.2022.2100644)]
+- Rainbow Health Ontario: [Sherbourne’s Guidelines for gender-affirming primary care with trans and non-binary patients](https://www.rainbowhealthontario.ca/product/4th-edition-sherbournes-guidelines-for-gender-affirming-primary-care-with-trans-and-non-binary-patients/), 4th revision (2021) \[[PDF](https://rainbowhealth.wpenginepowered.com/wp-content/uploads/2021/06/Guidelines-FINAL-4TH-EDITION-c.pdf)]
+- Trans Care BC: [Gender-affirming Care for Trans, Two-Spirit, and Gender Diverse Patients in BC - A Primary Care Toolkit](http://www.phsa.ca/transcarebc/Documents/HealthProf/Primary-Care-Toolkit.pdf) (2021)
+
+- Fenway Health: [Medical Care of Trans and Gender Diverse Adults](https://www.lgbtqiahealtheducation.org/publication/medical-care-of-trans-and-gender-diverse-adults-2021/) (2021) \[[PDF](https://www.lgbtqiahealtheducation.org/wp-content/uploads/2021/07/Medical-Care-of-Trans-and-Gender-Diverse-Adults-Spring-2021.pdf)]
+- UCSF: [Guidelines for the Primary and Gender-Affirming Care of Transgender and Gender Nonbinary People](https://transcare.ucsf.edu/guidelines) (2016)\
+  *Note that cyproterone acetate (CPA), not marketed in the United States, was mentioned little or recommended against its use in Fenway Health and UCSF guidelines.*

--- a/content.en/science.md
+++ b/content.en/science.md
@@ -9,7 +9,6 @@ weight: 4
 
 ## MtF HRT
 
-- [Transfeminine Science](https://transfemscience.org)
 - [Androgen Receptor Repeat Length Polymorphism Associated with Male-to-Female Transsexualism](https://doi.org/10.1016/j.biopsych.2008.08.033) (2008)
 
 ## MtF SRS

--- a/content.zh-cn/hrt.md
+++ b/content.zh-cn/hrt.md
@@ -8,7 +8,8 @@ weight: 1
 
 ## 用药
 
-- [Shizu&rsquo;s HRT Guide](https://docs.hrt.guide)
+- [Shizu&rsquo;s 跨性别女性 HRT 资料兼指南](https://docs.hrt.guide)
+- [Transfeminine Science 中文译本存档站](https://tfsci.mtf.wiki) - 还有常用药品说明书喔
 
 ## 诊断证明
 

--- a/content.zh-cn/science.md
+++ b/content.zh-cn/science.md
@@ -13,8 +13,6 @@ weight: 7
 ## MtF HRT
 
 - [Androgen Receptor Repeat Length Polymorphism Associated with Male-to-Female Transsexualism](https://doi.org/10.1016/j.biopsych.2008.08.033). (2008)
-- [“女性倾向跨性别者科学”中文译本存档站](https://tfsci.mtf.wiki/zh-cn/)\
-  原站：[Transfeminine Science](https://transfemscience.org)（英文）
 
 ## MtF SRS
 
@@ -36,3 +34,16 @@ weight: 7
 
 - [性别选择权：性质界定与法权塑造](https://doi.org/10.16164/j.cnki.22-1062/c.2018.02.002) (2018)
 - [变性人结婚法律问题研究](https://cdmd.cnki.com.cn/Article/CDMD-10542-1016092833.htm) (2016)
+
+## 跨性别护理指南
+
+以下指南均仅有英文版本。
+
+- WPATH SOC8——《[跨性别及性别多元化人群健康护理标准](https://www.wpath.org/publications/soc)》第八版 (2022) \[[PDF](https://www.tandfonline.com/doi/pdf/10.1080/26895269.2022.2100644)]
+- 安大略彩虹健康项目——《[跨性别及性别多元化人群的初级性别肯定治疗指南](https://www.rainbowhealthontario.ca/product/4th-edition-sherbournes-guidelines-for-gender-affirming-primary-care-with-trans-and-non-binary-patients/)》 (2021) \[[PDF](https://rainbowhealth.wpenginepowered.com/wp-content/uploads/2021/06/Guidelines-FINAL-4TH-EDITION-c.pdf)]
+- Trans Care BC——《[初级治疗工具包：适用于不列颠哥伦比亚省的跨性别、双重人格及性别多元化人群的性别肯定治疗](http://www.phsa.ca/transcarebc/Documents/HealthProf/Primary-Care-Toolkit.pdf)》 (2021)
+
+
++ 芬威健康——《[跨性别及性别多元化人群的治疗](https://www.lgbtqiahealtheducation.org/publication/medical-care-of-trans-and-gender-diverse-adults-2021/)》 (2021) \[[PDF](https://www.lgbtqiahealtheducation.org/wp-content/uploads/2021/07/Medical-Care-of-Trans-and-Gender-Diverse-Adults-Spring-2021.pdf)]
++ 加州大学旧金山分校——《[跨性别及非二元性别人群的初级性别肯定治疗指南](https://transcare.ucsf.edu/guidelines)》 (2016) \
+  注：以上二者鲜少提及或反对醋酸环丙孕酮的使用（在美国未上市）。

--- a/content.zh-tw/hrt.md
+++ b/content.zh-tw/hrt.md
@@ -8,6 +8,7 @@ weight: 1
 - [跨性別女性化賀爾蒙療法](https://www.cmuh.cmu.edu.tw/NewsInfo/NewsArticle?no=6907)（中國醫藥大學）
 - [女性化賀爾蒙治療 HRT 基礎知識](https://www.dcard.tw/f/trans/p/235957290)（台灣性別不明關懷協會）
 - [[討論] 關於 HRT(MtF)的心得](https://www.ptt.cc/bbs/transgender/M.1603946909.A.739.html)（mopplayer）
+- [Transfeminine Science 中文譯本存檔站](https://tfsci.mtf.wiki) - 還有常用藥品說明書喔
 
 ## 跨性別男性化 {#ftm}
 


### PR DESCRIPTION
严格来说，Transfeminine Science不属于学术文献，故迁移至HRT。同时添入 5 份跨性别护理指南到“学术研究进展”：指南（尤其SOC8）是世界范围内跨性别健康领域研究成果的集大成之作，集合了该领域各专家的共识。