### PR TITLE
ko: add Korean language with orgs and resources

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,14 @@ languages:
     weight: 4
     social:
       twitter: MtFwikiJapan
+  ko:
+    title: 2345.LGBT 트랜스젠더 포털
+    contentDir: content.ko
+    languageName: 대한민국（한국어）
+    params:
+      shortName: KR
+    timeZone: Asia/Seoul
+    weight: 5
   en:
     title: Awesome Trans - Transgender Portal
     contentDir: content.en
@@ -82,7 +90,7 @@ languages:
     params:
       shortName: EN
     timeZone: UTC
-    weight: 5
+    weight: 6
   nl:
     title: Awesome Trans - Transgender Portaal
     contentDir: content.nl
@@ -90,4 +98,4 @@ languages:
     params:
       shortName: NL
     timeZone: Europe/Amsterdam
-    weight: 6
+    weight: 7

--- a/content.ko/_index.md
+++ b/content.ko/_index.md
@@ -1,0 +1,39 @@
+---
+title: 사이트
+description: 트랜스젠더 포털
+brand: '{{< brand >}}'
+slogan: '{{< brand >}} 트랜스젠더 포털'
+featured:
+  - title: MtF.wiki
+    url: https://mtf.wiki/
+  - title: 트랜스로드맵
+    url: http://transroadmap.net/
+links:
+  - title: 트랜스로드맵
+    tags: [General]
+    url: http://transroadmap.net/
+  - title: 페미위키 — 트랜스젠더
+    tags: [Wiki]
+    url: https://femiwiki.com/w/%ED%8A%B8%EB%9E%9C%EC%8A%A4%EC%A0%A0%EB%8D%94
+  - title: 위키백과 — 트랜스젠더 호르몬 치료 (MTF)
+    tags: [MtF, HRT]
+    url: https://ko.wikipedia.org/wiki/%ED%8A%B8%EB%9E%9C%EC%8A%A4%EC%A0%A0%EB%8D%94_%ED%98%B8%EB%A5%B4%EB%AA%AC_%EC%B9%98%EB%A3%8C_(MTF)
+  - title: 위키백과 — 트랜스젠더 호르몬 치료 (FTM)
+    tags: [FtM, HRT]
+    url: https://ko.wikipedia.org/wiki/%ED%8A%B8%EB%9E%9C%EC%8A%A4%EC%A0%A0%EB%8D%94_%ED%98%B8%EB%A5%B4%EB%AA%AC_%EC%B9%98%EB%A3%8C_(FTM)
+  - title: 나무위키 — 트랜스젠더 호르몬 치료
+    tags: [HRT]
+    url: https://namu.wiki/w/%ED%8A%B8%EB%9E%9C%EC%8A%A4%EC%A0%A0%EB%8D%94%20%ED%98%B8%EB%A5%B4%EB%AA%AC%20%EC%B9%98%EB%A3%8C
+  - title: 나무위키 — 트랜스여성
+    tags: [MtF]
+    url: https://namu.wiki/w/%ED%8A%B8%EB%9E%9C%EC%8A%A4%EC%97%AC%EC%84%B1
+  - title: 나무위키 — 트랜스남성
+    tags: [FtM]
+    url: https://namu.wiki/w/%ED%8A%B8%EB%9E%9C%EC%8A%A4%EB%82%A8%EC%84%B1
+  - title: Net4TS (넷포)
+    tags: [Community]
+    url: https://net4ts.com/
+  - title: 트랜스젠더 마이너 갤러리
+    tags: [Community]
+    url: https://gall.dcinside.com/mgallery/board/lists/?id=tg74
+---

--- a/content.ko/organization.md
+++ b/content.ko/organization.md
@@ -1,0 +1,18 @@
+---
+title: 단체
+weight: 3
+---
+
+## 트랜스젠더 단체
+
+- [트랜스해방전선](https://x.com/freetransright)
+- [트랜스젠더 인권단체 조각보](https://transgender.or.kr/)
+- [변희수재단](https://bhsfoundation.or.kr/)
+- [튤립연대 — 청소년 트랜스젠더 인권모임](https://x.com/youthtranskor)
+
+## 성소수자 단체
+
+- [행동하는성소수자인권연대 (행성인)](https://lgbtpride.or.kr/)
+- [성소수자부모모임 (PFLAG Korea)](https://www.pflagkorea.org/)
+- [SOGI법정책연구회](https://sogilaw.org/)
+- [청소년 성소수자 위기지원센터 띵동](https://ddingdong.kr/)


### PR DESCRIPTION
## Summary

- Adds the **Korean (ko)** locale to 2345.LGBT.
- `content.ko/_index.md` — Korean trans-resource links (Trans Roadmap, Femiwiki, namu wiki / Wikipedia hormone-therapy articles, Net4TS, etc.).
- `content.ko/organization.md` — Korean trans-rights and LGBT advocacy orgs (조각보, 트랜스해방전선, 변희수재단, 튤립연대, 행성인, PFLAG Korea, SOGI법정책연구회, 띵동).
- Registers `ko` in `config.yaml` after `ja` (weight 5); shifts `en` to 6 and `nl` to 7.