### PR TITLE
ja: add orgs, university circles, FtM info magazine and KG Rainbow Week

### DIFF
--- a/content.ja/_index.md
+++ b/content.ja/_index.md
@@ -14,6 +14,12 @@ links:
   - title: MtF 情報発信サイト
     tags: [Blog]
     url: https://joseika.com
+  - title: 乙女塾
+    tags: [MtF]
+    url: https://otomejuku.jp/
+  - title: LGBTER — Transgender(MtF) 記事一覧
+    tags: [MtF, Blog]
+    url: https://lgbter.jp/noise_cat/mtf/
   - title: スザンヌみさき公式ブログ
     tags: [Blog]
     url: http://naowasada.xsrv.jp

--- a/content.ja/_index.md
+++ b/content.ja/_index.md
@@ -41,4 +41,13 @@ links:
   - title: GID治療院一覧（ホルモン治療）
     tags: [Map]
     url: https://g-pit.com/gidclinics/
+  - title: FTMのための情報note
+    tags: [FtM, Blog]
+    url: https://note.com/ftm_info
+  - title: 大阪府 FTM テストステロン注射可能病院一覧
+    tags: [FtM, HRT, Maps]
+    url: https://note.com/ftm_info/n/n942b73da9c73
+  - title: K.G. Rainbow Week（関西学院大学）
+    tags: [Event]
+    url: https://kgrainbowweek.com/
 ---

--- a/content.ja/organization.md
+++ b/content.ja/organization.md
@@ -1,0 +1,69 @@
+---
+title: 団体・サークル
+weight: 3
+---
+
+## 全国組織・NPO
+
+- [認定NPO法人 ReBit](https://rebitlgbt.org/)
+- [認定NPO法人 虹色ダイバーシティ](https://nijiirodiversity.jp/)
+- [一般社団法人 LGBT法連合会](https://lgbtetc.jp/)
+- [認定NPO法人 LGBTの家族と友人をつなぐ会](https://lgbt-family.or.jp/)
+- [一般社団法人 fair](https://fairs-fair.org/)
+- [マリッジ・フォー・オール・ジャパン](https://www.marriageforall.jp/)
+- [認定NPO法人 東京レインボープライド](https://tokyorainbowpride.com/)
+- [NPO法人 Rainbow Soup（福岡）](https://rainbowsoup.net/)
+
+## トランスジェンダー関連
+
+- [日本 GID/GD と共に生きる人々の会](https://gid.jp)
+- [LIBERTY（性別不合当事者会）](https://gid-liberty.com/)
+
+## 大学サークル
+
+### 関西
+
+- [大阪大学 Libra](https://x.com/handai_libra)
+- [関西学院大学 K.G. Rainbow Week](https://kgrainbowweek.com/)
+- [関西学院大学 Rainbows](https://x.com/kscrainbows)
+- [関西大学 kufree](https://x.com/kufreeLGBT)
+- [京都大学 にじいろきょうと](https://x.com/regenbogenkyoto)
+- [同志社大学 d_gradation](https://x.com/d_gradation)
+- [立命館大学 colorfree](https://x.com/Rits_colorfree)
+- [龍谷大学 sbylgbtq](https://x.com/sbylgbtq)
+
+### 関東
+
+- [東京大学 UT-topos](http://topos.lolipop.jp/)
+- [東京大学 Porta Rubra for LGBT@UT](https://portarubra.org/)
+- [早稲田大学 GLOW](https://waseda-glow.com/)
+- [慶應義塾大学 LGBT塾生会](https://x.com/Kolours2012)
+- [上智大学 KIO LGBT Salon](https://x.com/kioiLgbt)
+- [立教大学 saintpaulia](https://x.com/R_saintpaulia)
+- [明治大学 arcoiris](https://x.com/meiji_arcoiris)
+- [法政大学 doublerainbow](https://x.com/doublerainbow_h)
+- [国際基督教大学 sumposion](https://x.com/sumposion)
+- [横浜国立大学 YNUQueer](https://x.com/YNUQueer)
+- [筑波大学 circleq](https://x.com/circleq9)
+
+### 北海道・東北
+
+- [北海道大学 gabgab](https://x.com/hokudaigabgab)
+- [東北大学 rb_mitocon](https://x.com/rb_mitocon)
+
+### 中部
+
+- [名古屋大学 LGBT サークル](https://x.com/nu_lgbt)
+
+### 中国・四国
+
+- [広島大学 HULAT](https://x.com/hulat_lgbts)
+
+### 九州
+
+- [九州大学 ARCUS](https://x.com/arcus_qu)
+- [福岡大学 FLAG](https://x.com/flag_fu)
+
+### 一覧・参考
+
+- [Stonewall Japan — LGBT University Groups](https://stonewalljapan.org/resources/lgbt-university-groups/)

--- a/content.ja/organization.md
+++ b/content.ja/organization.md
@@ -19,6 +19,35 @@ weight: 3
 - [日本 GID/GD と共に生きる人々の会](https://gid.jp)
 - [LIBERTY（性別不合当事者会）](https://gid-liberty.com/)
 
+## コミュニティセンター・地域団体
+
+### 北海道・東北
+
+- [NPO法人 北海道レインボー・リソースセンター L-Port（札幌）](https://l-port.net/)
+- [さっぽろレインボープライド](https://www.sprrainbowpride.com/)
+
+### 関東
+
+- [プライドハウス東京レガシー](https://pridehouse.jp/)
+- [NPO法人 SHIP（横浜）](https://ship.or.jp/)
+- [SHIPにじいろキャビン（横浜）](https://ship.or.jp/cabin/)
+
+### 中部
+
+- [特定非営利活動法人 PROUD LIFE（名古屋）](https://proudlife.org/)
+- [名古屋レインボープライド](https://nagoyarainbowpride.com/)
+- [レインボーなごや](https://rainbow758.wixsite.com/rainbow-nagoya)
+
+### 関西
+
+- [プライドセンター大阪](https://pridecenter.jp/)
+- [NPO法人 QWRC（大阪）](https://qwrc.org/)
+- [関西クィア映画祭](https://ja.wikipedia.org/wiki/関西クィア映画祭)
+
+### 九州・沖縄
+
+- [ピンクドット沖縄](https://pinkdot-okinawa.com/)
+
 ## 大学サークル
 
 ### 関西


### PR DESCRIPTION
## Summary

- Adds **`content.ja/organization.md`** with curated national Japanese LGBT NPOs, trans-specific groups, and university circles grouped by region (関西・関東・北海道・東北・中部・中国・四国・九州).
- Updates **`content.ja/_index.md`** with three new links:
  - `note.com/ftm_info` (FTMのための情報note magazine)
  - The Osaka-prefecture FTM testosterone-clinic directory article
  - K.G. Rainbow Week (関西学院大学 annual event aligned with IDAHOT)
