### PR TITLE
docs: 新增韩国跨性别社群与 SRS / 医疗资源条目（en · zh-cn）

### DIFF
--- a/content.en/_index.md
+++ b/content.en/_index.md
@@ -85,4 +85,22 @@ links:
   - title: One Among Us Transgender Support
     tags: [Community]
     url: https://oneamongus.ca
+  - title: SOGI Law & Policy Research Group (Korea)
+    tags: [General, Korea]
+    url: https://sogilaw.org/
+  - title: Jogakbo — Trans Human Rights Group (Korea)
+    tags: [Community, Korea]
+    url: https://transgender.or.kr/
+  - title: Solidarity for LGBT Human Rights of Korea
+    tags: [Community, Korea]
+    url: https://lgbtpride.or.kr/
+  - title: Trans Liberation Front (Korea)
+    tags: [Community, Korea]
+    url: https://femiwiki.com/w/%ED%8A%B8%EB%9E%9C%EC%8A%A4%ED%95%B4%EB%B0%A9%EC%A0%84%EC%84%A0
+  - title: TransHealthCare — Korea Surgeons
+    tags: [MtF, SRS, Korea]
+    url: https://www.transhealthcare.org/south-korea/
+  - title: Transgender Map — South Korea
+    tags: [MtF, SRS, Korea]
+    url: https://www.transgendermap.com/guidance/medical/surgery/south-korea/
 ---

--- a/content.zh-cn/_index.md
+++ b/content.zh-cn/_index.md
@@ -79,4 +79,19 @@ links:
   - title: 跨性别相关知识科普站
     tags: [MtF, FtM]
     url: https://aboutrans.info/
+  - title: SOGI 法政策研究会（韩国）
+    tags: [社区, 韩国]
+    url: https://sogilaw.org/
+  - title: 跨性别人权团体 片片布 Jogakbo（韩国）
+    tags: [社区, 韩国]
+    url: https://transgender.or.kr/
+  - title: 行动中性少数者人权连带（韩国）
+    tags: [社区, 韩国]
+    url: https://lgbtpride.or.kr/
+  - title: TransHealthCare — 韩国医师目录
+    tags: [MtF, SRS, 韩国]
+    url: https://www.transhealthcare.org/south-korea/
+  - title: Transgender Map — 韩国
+    tags: [MtF, SRS, 韩国]
+    url: https://www.transgendermap.com/guidance/medical/surgery/south-korea/
 ---


### PR DESCRIPTION
## 概要

补充以 **韩国** 为对象国家的社群组织与 SRS / 医疗资源条目，使 2345.LGBT 在英文与简体中文 locale 下与既有的 UK / 中国大陆等国家级条目同样具备韩国相关入口。

本 PR 仅增条目，不动既有内容与排序，亦不动 `config.yaml`。

## 新增

### `content.en/_index.md`

- **SOGI Law & Policy Research Group (Korea)** — tags: `[General, Korea]`，<https://sogilaw.org/>
- **Jogakbo — Trans Human Rights Group (Korea)** — tags: `[Community, Korea]`，<https://transgender.or.kr/>
- **Solidarity for LGBT Human Rights of Korea** — tags: `[Community, Korea]`，<https://lgbtpride.or.kr/>
- **Trans Liberation Front (Korea)** — tags: `[Community, Korea]`
- **TransHealthCare — Korea Surgeons** — tags: `[MtF, SRS, Korea]`，<https://www.transhealthcare.org/south-korea/>
- **Transgender Map — South Korea** — tags: `[MtF, SRS, Korea]`，<https://www.transgendermap.com/guidance/medical/surgery/south-korea/>

### `content.zh-cn/_index.md`

- **SOGI 法政策研究会（韩国）** — tags: `[社区, 韩国]`
- **跨性别人权团体 片片布 Jogakbo（韩国）** — tags: `[社区, 韩国]`
- **行动中性少数者人权连带（韩国）** — tags: `[社区, 韩国]`
- **TransHealthCare — 韩国医师目录** — tags: `[MtF, SRS, 韩国]`
- **Transgender Map — 韩国** — tags: `[MtF, SRS, 韩国]`

## 关联 PR

- 与 [#47](https://github.com/project-trans/2345.LGBT/pull/47)（`ko` locale 添加）互补——#47 负责新增韩语 `content.ko/` locale 与其内的本土组织列表，本 PR 负责在既有 `content.en/` · `content.zh-cn/` 两个 locale 下补充对韩国对象国家的导航。两者覆盖**不同文件**，**不冲突**，可并行合并。
- 与 [project-trans/MtF-wiki#1741](https://github.com/project-trans/MtF-wiki/pull/1741)（MtF wiki 内韩语本地化与韩国 SRS / HRT / 法律内容）配合——本 PR 提供的链接与 MtF wiki 内韩文页面所引用的同一组韩国本土资源相互一致。
- 与 [project-trans/Next-MtF-wiki#31](https://github.com/project-trans/Next-MtF-wiki/pull/31)（Next-MtF-wiki app 侧 ko 支持）配合——本 PR 提供的导航站条目在 MtF wiki ko 版上线后是其用户的入口之一。

## Test plan

- [ ] Hugo 在 en / zh-cn 两个 locale 下能正确解析新增 entries 的 YAML
- [ ] 标签筛选时 `Korea` / `韩国` 标签生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)