### PR TITLE
收录 KiraMyao Equal：2026 调研报告与项目主页

### DIFF
--- a/content.zh-cn/_index.md
+++ b/content.zh-cn/_index.md
@@ -79,4 +79,7 @@ links:
   - title: 跨性别相关知识科普站
     tags: [MtF, FtM]
     url: https://aboutrans.info/
+  - title: KiraMyao Equal
+    tags: [社区]
+    url: https://kiramyao.com/
 ---

--- a/content.zh-cn/other.md
+++ b/content.zh-cn/other.md
@@ -45,6 +45,7 @@ weight: 1000
 
 - [LGBTQIA in China](https://github.com/LGBT-CN/LGBTQIA-In-China)
 - [多元性別中文数字图书馆](https://transchinese.org/)
+- [KiraMyao Equal](https://kiramyao.com/)
 
 ## 周边商品 {#shop}
 

--- a/content.zh-cn/reports.md
+++ b/content.zh-cn/reports.md
@@ -6,6 +6,7 @@ weight: 5
 
 ## 报告 {#reports}
 
+- [2026 中文在线社区跨性别群体生活状况调研报告](https://kiramyao.com/report/2026-transgender-life-survey-reader-edition) (2026)\n  12 章、32 张图表，含执行摘要与交叉对比分析，全文在线阅读。
 - [2021 全国跨性别健康调研报告](https://cnlgbtdata.com/files/uploads/2023/01/2021全国跨性别健康调研报告.pdf) (2023)
 - [公众对变性人士权利的看法：中国](https://williamsinstitute.law.ucla.edu/publications/opinion-trans-rights-china/) (2021)\
   本报告介绍了有关中国变性人士及其权利的民意信息。


### PR DESCRIPTION
您好！

申请收录 KiraMyao Equal（https://kiramyao.com/ ）——一个关注性别多元群体的独立研究、公共知识与数字公益项目。

变更内容：

- `reports.md` 报告区新增「2026 中文在线社区跨性别群体生活状况调研报告」（12 章、32 张图表，v1.1 全文在线阅读）
- `other.md` 组织机构新增 KiraMyao Equal（纯链接，与同节格式一致）
- `_index.md` 首页卡片新增 KiraMyao Equal（社区）

提交为 GitHub 服务端签名的 Verified 提交，满足仓库 verified signatures 要求（替代此前无签名的 #53）。

站点运营跨性别真实经历故事库（Stories，130+ 篇社群投稿，每篇含独立永久链接）与调研报告。如需调整分类、措辞或补充其他语言版本，我们很乐意配合。

联系方式：report@kiramyao.com
谢谢！